### PR TITLE
Add support for specifying GitHub release versions

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -16,11 +16,11 @@ jobs:
       - name: "npm run build"
         run: npm run build
 
-        env:
-          # this is needed for the tests to pass
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "npm run test"
         run: npm run test
+        env:
+          # this is needed for the tests to execute
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "npm audit"
         run: npm audit

--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -16,6 +16,9 @@ jobs:
       - name: "npm run build"
         run: npm run build
 
+        env:
+          # this is needed for the tests to pass
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "npm run test"
         run: npm run test
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,16 +9,17 @@ jobs:
         config:
           - {
               os: "ubuntu-latest",
-              url: "https://get.helm.sh/helm-v3.0.0-beta.3-linux-amd64.tar.gz",
-              name: "hb3",
+              url: "https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz",
+              name: "h3",
               pathInArchive: "linux-amd64/helm",
             }
           - {
               os: "windows-latest",
-              url: "https://get.helm.sh/helm-v3.0.0-beta.3-windows-amd64.zip",
-              name: "hb3.exe",
+              url: "https://get.helm.sh/helm-v3.3.0-windows-amd64.zip",
+              name: "h3.exe",
               pathInArchive: "windows-amd64/helm.exe",
             }
+
     steps:
       - uses: actions/checkout@v2
       - name: "npm install"
@@ -33,4 +34,4 @@ jobs:
           pathInArchive: ${{ matrix.config.pathInArchive }}
       - name: Testing
         run: |
-          hb3 --help
+          h3 --help

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,10 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v2
+      - name: "npm install"
+        run: npm install
+      - name: "npm run build"
+        run: npm run build
 
       - uses: ./
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: "PR Checks"
+name: "URL E2E"
 on: [pull_request, push]
 
 jobs:
@@ -20,6 +20,8 @@ jobs:
               pathInArchive: "windows-amd64/helm.exe",
             }
     steps:
+      - uses: actions/checkout@v2
+
       - uses: ./
         with:
           name: ${{ matrix.config.name }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,30 @@
+name: "PR Checks"
+on: [pull_request, push]
+
+jobs:
+  configurator:
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - {
+              os: "ubuntu-latest",
+              url: "https://get.helm.sh/helm-v3.0.0-beta.3-linux-amd64.tar.gz",
+              name: "hb3",
+              pathInArchive: "linux-amd64/helm",
+            }
+          - {
+              os: "windows-latest",
+              url: "https://get.helm.sh/helm-v3.0.0-beta.3-windows-amd64.zip",
+              name: "hb3.exe",
+              pathInArchive: "windows-amd64/helm.exe",
+            }
+    steps:
+      - uses: ./
+        with:
+          name: ${{ matrix.config.name }}
+          url: ${{ matrix.config.url }}
+          pathInArchive: ${{ matrix.config.pathInArchive }}
+      - name: Testing
+        run: |
+          hb3 --help

--- a/.github/workflows/gh-release-latest.yml
+++ b/.github/workflows/gh-release-latest.yml
@@ -1,0 +1,25 @@
+name: "GitHub Releases E2E"
+on: [pull_request, push]
+
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "npm install"
+        run: npm install
+      - name: "npm run build"
+        run: npm run build
+
+      - uses: ./
+        with:
+          name: "kind"
+          fromGitHubReleases: "true"
+          repo: "kubernetes-sigs/kind"
+          urlTemplate: "https://github.com/kubernetes-sigs/kind/releases/download/{{version}}/kind-linux-amd64"
+          version: "latest"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Testing
+        run: |
+          kind --help

--- a/.github/workflows/gh-releases.yml
+++ b/.github/workflows/gh-releases.yml
@@ -9,13 +9,13 @@ jobs:
         config:
           - {
               os: "ubuntu-latest",
-              url: "https://get.helm.sh/helm-${{version}}-linux-amd64.tar.gz",
+              url: "https://get.helm.sh/helm-{{version}}-linux-amd64.tar.gz",
               name: "hb3",
               pathInArchive: "linux-amd64/helm",
             }
           - {
               os: "windows-latest",
-              urlTemplate: "https://get.helm.sh/helm-${{version}}-windows-amd64.zip",
+              urlTemplate: "https://get.helm.sh/helm-{{version}}-windows-amd64.zip",
               name: "hb3.exe",
               pathInArchive: "windows-amd64/helm.exe",
             }

--- a/.github/workflows/gh-releases.yml
+++ b/.github/workflows/gh-releases.yml
@@ -9,7 +9,7 @@ jobs:
         config:
           - {
               os: "ubuntu-latest",
-              url: "https://get.helm.sh/helm-{{version}}-linux-amd64.tar.gz",
+              urlTemplate: "https://get.helm.sh/helm-{{version}}-linux-amd64.tar.gz",
               name: "hb3",
               pathInArchive: "linux-amd64/helm",
             }
@@ -30,8 +30,8 @@ jobs:
         with:
           name: ${{ matrix.config.name }}
           repo: "helm/helm"
-          version: "^v3.3.0"
-          urlTemplate: ${{ matrix.config.url }}
+          version: "^v3.1.2"
+          urlTemplate: ${{ matrix.config.urlTemplate }}
           pathInArchive: ${{ matrix.config.pathInArchive }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Testing

--- a/.github/workflows/gh-releases.yml
+++ b/.github/workflows/gh-releases.yml
@@ -1,0 +1,33 @@
+name: "PR Checks"
+on: [pull_request, push]
+
+jobs:
+  configurator:
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - {
+              os: "ubuntu-latest",
+              url: "https://get.helm.sh/helm-${{version}}-linux-amd64.tar.gz",
+              name: "hb3",
+              pathInArchive: "linux-amd64/helm",
+            }
+          - {
+              os: "windows-latest",
+              urlTemplate: "https://get.helm.sh/helm-${{version}}-windows-amd64.zip",
+              name: "hb3.exe",
+              pathInArchive: "windows-amd64/helm.exe",
+            }
+    steps:
+      - uses: ./
+        with:
+          name: ${{ matrix.config.name }}
+          repo: "helm/helm"
+          version: "^v3.3.0"
+          urlTemplate: ${{ matrix.config.url }}
+          pathInArchive: ${{ matrix.config.pathInArchive }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Testing
+        run: |
+          hb3 --help

--- a/.github/workflows/gh-releases.yml
+++ b/.github/workflows/gh-releases.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: ./
         with:
           name: ${{ matrix.config.name }}
+          fromGitHubReleases: "true"
           repo: "helm/helm"
           version: "^v3.1.2"
           urlTemplate: ${{ matrix.config.urlTemplate }}

--- a/.github/workflows/gh-releases.yml
+++ b/.github/workflows/gh-releases.yml
@@ -10,13 +10,13 @@ jobs:
           - {
               os: "ubuntu-latest",
               urlTemplate: "https://get.helm.sh/helm-{{version}}-linux-amd64.tar.gz",
-              name: "hb3",
+              name: "h3",
               pathInArchive: "linux-amd64/helm",
             }
           - {
               os: "windows-latest",
               urlTemplate: "https://get.helm.sh/helm-{{version}}-windows-amd64.zip",
-              name: "hb3.exe",
+              name: "h3.exe",
               pathInArchive: "windows-amd64/helm.exe",
             }
     steps:
@@ -37,4 +37,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Testing
         run: |
-          hb3 --help
+          h3 --help

--- a/.github/workflows/gh-releases.yml
+++ b/.github/workflows/gh-releases.yml
@@ -21,6 +21,10 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v2
+      - name: "npm install"
+        run: npm install
+      - name: "npm run build"
+        run: npm run build
 
       - uses: ./
         with:

--- a/.github/workflows/gh-releases.yml
+++ b/.github/workflows/gh-releases.yml
@@ -1,4 +1,4 @@
-name: "PR Checks"
+name: "GitHub Releases E2E"
 on: [pull_request, push]
 
 jobs:
@@ -20,6 +20,8 @@ jobs:
               pathInArchive: "windows-amd64/helm.exe",
             }
     steps:
+      - uses: actions/checkout@v2
+
       - uses: ./
         with:
           name: ${{ matrix.config.name }}

--- a/.github/workflows/test-exe.yml
+++ b/.github/workflows/test-exe.yml
@@ -1,0 +1,20 @@
+name: "Test plain file"
+on: [pull_request, push]
+
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "npm install"
+        run: npm install
+      - name: "npm run build"
+        run: npm run build
+
+      - uses: ./
+        with:
+          name: "kind"
+          url: "https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64"
+      - name: Testing
+        run: |
+          kind --help

--- a/.github/workflows/test-tar-gz.yml
+++ b/.github/workflows/test-tar-gz.yml
@@ -1,0 +1,21 @@
+name: "Test .tar.gz"
+on: [pull_request, push]
+
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "npm install"
+        run: npm install
+      - name: "npm run build"
+        run: npm run build
+
+      - uses: ./
+        with:
+          name: "h3"
+          url: "https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz"
+          pathInArchive: "linux-amd64/helm"
+      - name: Testing
+        run: |
+          h3 --help

--- a/.github/workflows/test-zip-win.yml
+++ b/.github/workflows/test-zip-win.yml
@@ -1,0 +1,21 @@
+name: "Test .zip"
+on: [pull_request, push]
+
+jobs:
+  kind:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "npm install"
+        run: npm install
+      - name: "npm run build"
+        run: npm run build
+
+      - uses: ./
+        with:
+          name: "h3.exe"
+          url: "https://get.helm.sh/helm-v3.3.0-windows-amd64.zip"
+          pathInArchive: "windows-amd64/helm.exe"
+      - name: Testing
+        run: |
+          h3 --help

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # @engineerd/configurator
 
-Cross-platform GitHub Action for downloading statically compiled tools (or extracting them from an archive) and adding them to the path.
-This has been tested on `ubuntu-latest` and `windows-latest`.
+Cross-platform GitHub Action for downloading statically compiled tools (or
+extracting them from an archive) and adding them to the path. This has been
+tested on `ubuntu-latest`, `windows-latest`, and `macos-latest`.
 
 Inputs:
 
 - `name`: name your tool will be configured with (required)
 - `url`: URL to download your tool from (required)
-- `pathInArchive`: if the URL points to an archive, this field is required, and points to the path of the tool to configure (relative to the archive root).
+- `pathInArchive`: if the URL points to an archive, this field is required, and
+  points to the path of the tool to configure (relative to the archive root).
 
 Examples:
 
@@ -43,7 +45,8 @@ jobs:
           hb3 --help
 ```
 
-- download an executable from a given URL and move it to a folder in path with the given name:
+- download an executable from a given URL and move it to a folder in path with
+  the given name:
 
 ```yaml
 name: "Test plain file"
@@ -62,7 +65,8 @@ jobs:
           kind --help
 ```
 
-- download a `.tar.gz` archive from a given URL, and move a certain file from the archive directory to a folder in path, with a given name:
+- download a `.tar.gz` archive from a given URL, and move a certain file from
+  the archive directory to a folder in path, with a given name:
 
 ```yaml
 name: "Test .tar.gz"
@@ -82,7 +86,8 @@ jobs:
           hb3 --help
 ```
 
-- download a `.zip` archive on Windows from a given URL, and move a certain file from the archive directory to a folder in path, with a given name:
+- download a `.zip` archive on Windows from a given URL, and move a certain file
+  from the archive directory to a folder in path, with a given name:
 
 ```yaml
 name: "Test .zip"
@@ -102,6 +107,7 @@ jobs:
           hb3 --help
 ```
 
-> Note: usually, Windows-specific tooling uses `.zip` archives - and the `tar` utility on Windows doesn't seem to handle `.tar.gz` files properly.
-
-> Note: for Linux, `chmod +x` is called on the target file before moving it to the path, ensuring it is executable. On Windows this is skipped.
+> Note: usually, Windows-specific tooling uses `.zip` archives - and the `tar`
+> utility on Windows doesn't seem to handle `.tar.gz` files properly. Note: for
+> Linux, `chmod +x` is called on the target file before moving it to the path,
+> ensuring it is executable. On Windows this is skipped.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # @engineerd/configurator
 
 Cross-platform GitHub Action for downloading statically compiled tools (or
-extracting them from an archive) and adding them to the path. This has been
-tested on `ubuntu-latest`, `windows-latest`, and `macos-latest`.
+archives) and adding them to the path. This has been tested on `ubuntu-latest`,
+`windows-latest`, and `macos-latest`.
+
+This action can be used in two modes:
+
+- directly providing a download URL (or a URL per-platform, using a
+  configuration matrix)
+- providing a URL template and a semver version or range to be selected from
+  GitHub releases. In this mode, the action iterates through the GitHub releases
+  to find the latest version that satisfies the version (or range) constraint,
+  constructs the download URL, and adds the tool to the path.
+
+## Directly downloading tools based on URL
 
 Inputs:
 
 - `name`: name your tool will be configured with (required)
 - `url`: URL to download your tool from (required)
 - `pathInArchive`: if the URL points to an archive, this field is required, and
-  points to the path of the tool to configure (relative to the archive root).
+  points to the path of the tool to configure, relative to the archive root
 
-Examples:
-
-- cross platform action:
+Examples - a cross-platform action that downloads, extracts, and adds Helm
+v3.3.0 to the path:
 
 ```yaml
 jobs:
@@ -24,26 +34,123 @@ jobs:
         config:
           - {
               os: "ubuntu-latest",
-              url: "https://get.helm.sh/helm-v3.0.0-beta.3-linux-amd64.tar.gz",
-              name: "hb3",
+              url: "https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz",
+              name: "h3",
               pathInArchive: "linux-amd64/helm",
             }
           - {
               os: "windows-latest",
-              url: "https://get.helm.sh/helm-v3.0.0-beta.3-windows-amd64.zip",
-              name: "hb3.exe",
+              url: "https://get.helm.sh/helm-v3.3.0-windows-amd64.zip",
+              name: "h3.exe",
               pathInArchive: "windows-amd64/helm.exe",
             }
     steps:
-      - uses: engineerd/configurator@v0.0.2
+      - uses: engineerd/configurator@v0.0.3
         with:
           name: ${{ matrix.config.name }}
           url: ${{ matrix.config.url }}
           pathInArchive: ${{ matrix.config.pathInArchive }}
       - name: Testing
         run: |
-          hb3 --help
+          h3 --help
 ```
+
+## Selecting versions from GitHub Releases
+
+Inputs:
+
+- `name`: name your tool will be configured with (required)
+- `pathInArchive`: if the URL points to an archive, this field is required, and
+  points to the path of the tool to configure, relative to the archive root
+- `fromGitHubReleases`: if true, the action will attempt to get the latest
+  version from the specified repository's GitHub Releases that matches the given
+  semver version or range provided, and then construct the download URL using
+  the provided `urlTemplate`.
+- `repo`: GitHub repository of the tool. Used to list all releases and select
+  the proper version. Required if `fromGitHubReleases` is true.
+- `version`: an exact semver version or version range (specified with ^ or ~, as
+  defined and used by [NPM](https://docs.npmjs.com/about-semantic-versioning)).
+  If using semver ranges with `v0.x.x` releases, be sure to
+  [understand the semver behavior here](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004).
+  If `latest` is provided, the action will download the latest release
+  (respecting the `includePrereleases flag`), which, can break your action.
+  Required if `fromGitHubReleases` is true.
+- `token`: GitHub token used _only_ to list the GitHub releases for the supplied
+  repository. For most cases, its value should be `${{ secrets.GITHUB_TOKEN }}`.
+  Required if `fromGitHubReleases` is true.
+- `urlTemplate`: a URL template used to construct the download URL, together
+  with the desired version acquired from a GitHub release. For example,
+  `https://get.helm.sh/helm-{{version}}-linux-amd64.tar.gz` (the version
+  inserted here is the exact tag name from GitHub - check whether the tag name
+  contains any `v` before the version when constructing the URL template). Note
+  that this is [Mustache template](https://mustache.github.io/) (completely
+  separate from the GitHub Actions templating system - the template _must be_
+  `{{version}}`). Required if `fromGitHubReleases` is true.
+- `includePrereleases`: if true, the action will include pre-releases when
+  selecting a version from GitHub Releases.
+
+Example - a cross-platform action that selects the latest Helm version that
+satisfies the `^3.1.2` release constraint - meaning it selects any minor and
+patch update, or, in other words, the latest `v3.x.x` version:
+
+```yaml
+jobs:
+  configurator:
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - {
+              os: "ubuntu-latest",
+              urlTemplate: "https://get.helm.sh/helm-{{version}}-linux-amd64.tar.gz",
+              name: "hb3",
+              pathInArchive: "linux-amd64/helm",
+            }
+          - {
+              os: "windows-latest",
+              urlTemplate: "https://get.helm.sh/helm-{{version}}-windows-amd64.zip",
+              name: "h3.exe",
+              pathInArchive: "windows-amd64/helm.exe",
+            }
+    steps:
+      - uses: engineerd/configurator@v0.0.3
+        with:
+          name: ${{ matrix.config.name }}
+          pathInArchive: ${{ matrix.config.pathInArchive }}
+          fromGitHubReleases: "true"
+          repo: "helm/helm"
+          version: "^v3.1.2"
+          urlTemplate: ${{ matrix.config.urlTemplate }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Testing
+        run: |
+          h3 --help
+```
+
+Example - an action that selects the latest non-pre-release (as marked in the
+GitHub release) of Kind:
+
+```yaml
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: engineerd/configurator@v0.0.3
+        with:
+          name: "kind"
+          fromGitHubReleases: "true"
+          repo: "kubernetes-sigs/kind"
+          urlTemplate: "https://github.com/kubernetes-sigs/kind/releases/download/{{version}}/kind-linux-amd64"
+          version: "latest"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Testing
+        run: |
+          kind --help
+```
+
+## Other examples
 
 - download an executable from a given URL and move it to a folder in path with
   the given name:
@@ -56,10 +163,10 @@ jobs:
   kind:
     runs-on: ubuntu-latest
     steps:
-      - uses: engineerd/configurator@v0.0.2
+      - uses: engineerd/configurator@v0.0.3
         with:
           name: "kind"
-          url: "https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64"
+          url: "https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64"
       - name: Testing
         run: |
           kind --help
@@ -76,14 +183,14 @@ jobs:
   kind:
     runs-on: ubuntu-latest
     steps:
-      - uses: engineerd/configurator@v0.0.2
+      - uses: engineerd/configurator@v0.0.3
         with:
-          name: "hb3"
-          url: "https://get.helm.sh/helm-v3.0.0-beta.3-linux-amd64.tar.gz"
+          name: "h3"
+          url: "https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz"
           pathInArchive: "linux-amd64/helm"
       - name: Testing
         run: |
-          hb3 --help
+          h3 --help
 ```
 
 - download a `.zip` archive on Windows from a given URL, and move a certain file
@@ -97,14 +204,14 @@ jobs:
   kind:
     runs-on: windows-latest
     steps:
-      - uses: engineerd/configurator@v0.0.2
+      - uses: engineerd/configurator@v0.0.3
         with:
-          name: "hb3.exe"
-          url: "https://get.helm.sh/helm-v3.0.0-beta.3-windows-amd64.zip"
+          name: "h3.exe"
+          url: "https://get.helm.sh/helm-v3.3.0-windows-amd64.zip"
           pathInArchive: "windows-amd64/helm.exe"
       - name: Testing
         run: |
-          hb3 --help
+          h3 --help
 ```
 
 > Note: usually, Windows-specific tooling uses `.zip` archives - and the `tar`

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,31 @@ inputs:
     required: true
   url:
     description: 'URL to download your tool from'
-    required: true
+    required: false
   pathInArchive:
     description: 'If the URL points to an archive, this field is required, and points to the path of the tool to configure (relative to the archive root).'
+    required: false
+  
+  fromGitHubReleases:
+    default: "false"
+    required: false
+    description: "If true, the action will try to download the binary from a GitHub release, given a correct semver version or range, GitHub token, repository, and URL template for the binary."
+  repo:
+    required: false
+    description: "GitHub repository of the tool. Used to list all releases and select the proper version. Required if `fromGitHubReleases` is true."
+  version:
+    required: false
+    description: "An exact semver version or version range (specified with ^ or ~). Required if `fromGitHubReleases` is true."
+  token:
+    required: false
+    description: "GitHub token used to list the GitHub releases for the supplied repository. Required if `fromGitHubReleases` is true."
+  urlTemplate:
+    required: false
+    description: "Required if `fromGitHubReleases` is true."
+  includePrereleases:
+    required: false
+    default: "false"
+    description: "If true, the action will select a release marked as prerelease."
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/action.yml
+++ b/action.yml
@@ -1,37 +1,37 @@
-name: 'engineerd/configurator'
-description: 'Easy and cross-platform action to download, extract, and add to path statically compiled tools.'
-author: 'Engineerd'
+name: "engineerd/configurator"
+description: "Easy and cross-platform action to download, extract, and add to path statically compiled tools."
+author: "Engineerd"
 inputs:
   name:
-    description: 'Name your tool will be configured with'
+    description: "Name your tool will be configured with"
     required: true
   url:
-    description: 'URL to download your tool from'
+    description: "URL to download your tool from"
     required: false
   pathInArchive:
-    description: 'If the URL points to an archive, this field is required, and points to the path of the tool to configure (relative to the archive root).'
+    description: "If the URL points to an archive, this field is required, and points to the path of the tool to configure (relative to the archive root)."
     required: false
-  
+
   fromGitHubReleases:
     default: "false"
     required: false
-    description: "If true, the action will try to download the binary from a GitHub release, given a correct semver version or range, GitHub token, repository, and URL template for the binary."
+    description: "If true, the action will attempt to get the latest version from the specified repo's GitHub Releases that matches the given semver version or range provided, and then download it using the provided urlTemplate."
   repo:
     required: false
     description: "GitHub repository of the tool. Used to list all releases and select the proper version. Required if `fromGitHubReleases` is true."
   version:
     required: false
-    description: "An exact semver version or version range (specified with ^ or ~). Required if `fromGitHubReleases` is true."
+    description: "An exact semver version or version range (specified with ^ or ~). If `latest` is provided, the action will download the latest release (respecting the `includePrereleases flag`), which, can break your action. Required if `fromGitHubReleases` is true."
   token:
     required: false
     description: "GitHub token used to list the GitHub releases for the supplied repository. Required if `fromGitHubReleases` is true."
   urlTemplate:
     required: false
-    description: "Required if `fromGitHubReleases` is true."
+    description: "A URL template used to construct the download URL, together with the desired version acquired from a GitHub release. For example, `https://get.helm.sh/helm-{{version}}-linux-amd64.tar.gz` (the version inserted here is the exact tag name from GitHub - check whether the tag name contains any `v` before the version when constructing the URL template) .Required if `fromGitHubReleases` is true."
   includePrereleases:
     required: false
     default: "false"
-    description: "If true, the action will select a release marked as prerelease."
+    description: "If true, the action will include prereleases when selecting a version from GitHub Releases."
 runs:
-  using: 'node12'
-  main: 'lib/main.js'
+  using: "node12"
+  main: "lib/main.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,6 +197,11 @@
       "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
       "dev": true
     },
+    "@types/mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
+    },
     "@types/node": {
       "version": "12.6.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
@@ -215,7 +220,8 @@
     "@types/semver": {
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.3.tgz",
-      "integrity": "sha512-jQxClWFzv9IXdLdhSaTf16XI3NYe6zrEbckSpb5xhKfPbWgIyAY0AFyWWWfaiDcBuj3UHmMkCIwSRqpKMTZL2Q=="
+      "integrity": "sha512-jQxClWFzv9IXdLdhSaTf16XI3NYe6zrEbckSpb5xhKfPbWgIyAY0AFyWWWfaiDcBuj3UHmMkCIwSRqpKMTZL2Q==",
+      "dev": true
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -915,6 +921,11 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
+    "mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
+    },
     "node-environment-flags": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -1232,9 +1243,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "universal-user-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-mwpoNjHSWWh0IiALdDEQi3tru124JKn0yVNziIBzTME8QRv7thwoghVuT1jBRjFvdtoHsqD58IRHy1nf86paRg=="
     },
     "@actions/exec": {
       "version": "1.0.4",
@@ -15,6 +15,17 @@
       "integrity": "sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==",
       "requires": {
         "@actions/io": "^1.0.1"
+      }
+    },
+    "@actions/github": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-4.0.0.tgz",
+      "integrity": "sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==",
+      "requires": {
+        "@actions/http-client": "^1.0.8",
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.3",
+        "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
       }
     },
     "@actions/http-client": {
@@ -26,14 +37,14 @@
       }
     },
     "@actions/io": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.1.tgz",
-      "integrity": "sha512-rhq+tfZukbtaus7xyUtwKfuiCRXd1hWSfmJNEpFgBQJ4woqPEpsBw04awicjwz9tyG2/MVhAEMfVn664Cri5zA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
+      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
     "@actions/tool-cache": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.5.5.tgz",
-      "integrity": "sha512-y/YO37BOaXzOEHpvoGZDLCwvg6XZWQ7Ala4Np4xzrKD1r48mff+K/GAmzXMejnApU7kgqC6lL/aCKTZDCrhdmw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.6.0.tgz",
+      "integrity": "sha512-+fyEBImPD3m5I0o6DflCO0NHY180LPoX8Lo6y4Iez+V17kO8kfkH0VHxb8mUdmD6hn9dWA9Ch1JA20fXoIYUeQ==",
       "requires": {
         "@actions/core": "^1.2.3",
         "@actions/exec": "^1.0.0",
@@ -48,6 +59,97 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
+      }
+    },
+    "@octokit/auth-token": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+      "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^4.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.4.tgz",
+      "integrity": "sha512-ITpZ+dQc0cXAW1FmDkHJJM+8Lb6anUnin0VB5hLBilnYVdLC0ICFU/KIvT7OXfW9S81DE3U4Vx2EypDG1OYaPA==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.1.tgz",
+      "integrity": "sha512-81A+ONLpcSX7vWxnEmVZteQPNsbdeScSVUqjgMYPSk1trzG69iYkhS42wPRWtN0nYw6OEmT48DNeQCjHeyroYw==",
+      "requires": {
+        "@octokit/types": "^5.3.0"
+      }
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.3.tgz",
+      "integrity": "sha512-az3seq9yuc0OXlNLrZ0fWTNbFuL4sN8GN1sLmovELg3+LnpWmOs3GAn2KGa6E7SKMgpCuFvJwvsHEfYasTHUxQ==",
+      "requires": {
+        "@octokit/types": "^5.1.1",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^4.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "requires": {
+        "@octokit/types": "^5.0.1",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.1.tgz",
+      "integrity": "sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==",
+      "requires": {
+        "@types/node": ">= 8"
       }
     },
     "@types/chai": {
@@ -98,8 +200,7 @@
     "@types/node": {
       "version": "12.6.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
-      "dev": true
+      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
     },
     "@types/rimraf": {
       "version": "2.0.2",
@@ -110,6 +211,11 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
+    },
+    "@types/semver": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.3.tgz",
+      "integrity": "sha512-jQxClWFzv9IXdLdhSaTf16XI3NYe6zrEbckSpb5xhKfPbWgIyAY0AFyWWWfaiDcBuj3UHmMkCIwSRqpKMTZL2Q=="
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -187,6 +293,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
     },
     "binary-extensions": {
       "version": "2.0.0",
@@ -406,6 +517,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "diff": {
       "version": "3.5.0",
@@ -667,6 +783,11 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+      "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA=="
+    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -712,9 +833,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "log-symbols": {
@@ -802,7 +923,20 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -848,7 +982,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -943,10 +1076,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1105,6 +1237,11 @@
       "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -1182,8 +1319,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   "author": "Engineerd",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "1.2.4",
-    "@actions/tool-cache": "1.5.5",
-    "@actions/exec": "1.0.4",
-    "@actions/io": "^1.0.0"
+    "@actions/core": "^1.2.5",
+    "@actions/exec": "^1.0.4",
+    "@actions/github": "^4.0.0",
+    "@actions/io": "^1.0.2",
+    "@actions/tool-cache": "^1.6.0",
+    "semver": "^7.3.2"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",
@@ -31,6 +33,7 @@
     "@types/mocha": "^2.2.41",
     "@types/node": "^12.0.4",
     "@types/rimraf": "2.0.2",
+    "@types/semver": "^7.3.3",
     "chai": "^4.1.0",
     "chai-fs": "^2.0.0",
     "mocha": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/javascript-template.git"
+    "url": "git+https://github.com/engineerd/configurator.git"
   },
   "keywords": [
     "actions",
@@ -25,12 +25,14 @@
     "@actions/github": "^4.0.0",
     "@actions/io": "^1.0.2",
     "@actions/tool-cache": "^1.6.0",
+    "mustache": "^4.0.1",
     "semver": "^7.3.2"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/chai-fs": "^2.0.2",
     "@types/mocha": "^2.2.41",
+    "@types/mustache": "^4.0.1",
     "@types/node": "^12.0.4",
     "@types/rimraf": "2.0.2",
     "@types/semver": "^7.3.3",

--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -1,99 +1,137 @@
-import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
-import * as exec from '@actions/exec';
-import * as io from '@actions/io';
-import * as path from 'path';
-import * as os from 'os';
-
-export enum ArchiveType {
-    None = "",
-    TarGz = ".tar.gz",
-    Zip = ".zip",
-    SevenZ = ".7z"
-}
-
-export class Configurator {
-    name: string;
-    url: string;
-    pathInArchive: string;
-
-    constructor(name: string, url: string, pathInArchive: string) {
-        this.name = name;
-        this.url = url;
-        this.pathInArchive = pathInArchive;
-    }
-
-    getArchiveType(): ArchiveType {
-        if (this.url.endsWith(ArchiveType.TarGz)) return ArchiveType.TarGz;
-        if (this.url.endsWith(ArchiveType.Zip)) return ArchiveType.Zip;
-        if (this.url.endsWith(ArchiveType.SevenZ)) return ArchiveType.SevenZ;
-
-        return ArchiveType.None;
-    }
-
-    async configure() {
-        console.log(`Downloading tool from ${this.url}...`);
-        let downloadPath: string | null = null;
-        let archivePath: string | null = null;
-        const tempDir = path.join(os.tmpdir(), 'tmp', 'runner', 'temp');
-        await io.mkdirP(tempDir);
-        downloadPath = await tc.downloadTool(this.url);
-
-        switch (this.getArchiveType()) {
-            case ArchiveType.None:
-                return this.moveToPath(downloadPath);
-
-            case ArchiveType.TarGz:
-                archivePath = await tc.extractTar(downloadPath, tempDir);
-                return this.moveToPath(path.join(archivePath, this.pathInArchive));
-
-            case ArchiveType.Zip:
-                archivePath = await tc.extractZip(downloadPath, tempDir);
-                return this.moveToPath(path.join(archivePath, this.pathInArchive));
-            
-            case ArchiveType.SevenZ:
-                archivePath = await tc.extract7z(downloadPath, tempDir);
-                return this.moveToPath(path.join(archivePath, this.pathInArchive));
-        }
-    }
-
-    async moveToPath(downloadPath: string) {
-        let toolPath = binPath();
-        await io.mkdirP(toolPath);
-        await io.mv(downloadPath, path.join(toolPath, this.name));
-
-        if (process.platform !== 'win32') {
-            await exec.exec("chmod", ["+x", path.join(toolPath, this.name)])
-        }
-
-        core.addPath(toolPath);
-    }
-}
+import * as core from "@actions/core";
+import * as tc from "@actions/tool-cache";
+import * as exec from "@actions/exec";
+import * as io from "@actions/io";
+import * as path from "path";
+import * as os from "os";
 
 const NameInput: string = "name";
 const URLInput: string = "url";
 const PathInArchiveInput: string = "pathInArchive";
 
-export function getConfig(): Configurator {
-    const n: string = core.getInput(NameInput);
-    const u: string = core.getInput(URLInput);
-    const p: string = core.getInput(PathInArchiveInput);
+const FromGitHubReleases: string = "fromGitHubReleases";
+const Token: string = "token";
+const Repo: string = "repo";
+const Version: string = "version";
+const IncludePrereleases: string = "includePrereleases";
+const URLTemplate: string = "urlTemplate";
 
-    return new Configurator(n, u, p);
+export function getConfig(): Configurator {
+  return new Configurator(
+    core.getInput(NameInput),
+    core.getInput(URLInput),
+    core.getInput(PathInArchiveInput),
+
+    core.getInput(FromGitHubReleases),
+    core.getInput(Token),
+    core.getInput(Repo),
+    core.getInput(Version),
+    core.getInput(IncludePrereleases),
+    core.getInput(URLTemplate)
+  );
+}
+
+export class Configurator {
+  name: string;
+  url: string;
+  pathInArchive: string;
+
+  fromGitHubReleases: boolean;
+  token: string;
+  repo: string;
+  version: string;
+  includePrereleases: boolean;
+  urlTemplate: string;
+
+  constructor(
+    name: string,
+    url: string,
+    pathInArchive: string,
+    fromGitHubRelease: string,
+    token: string,
+    repo: string,
+    version: string,
+    includePrereleases: string,
+    urlTemplate: string
+  ) {
+    this.name = name;
+    this.url = url;
+    this.pathInArchive = pathInArchive;
+
+    this.fromGitHubReleases = fromGitHubRelease == "true";
+    this.token = token;
+    this.repo = repo;
+    this.version = version;
+    this.includePrereleases = includePrereleases == "true";
+    this.urlTemplate = urlTemplate;
+  }
+
+  getArchiveType(): ArchiveType {
+    if (this.url.endsWith(ArchiveType.TarGz)) return ArchiveType.TarGz;
+    if (this.url.endsWith(ArchiveType.Zip)) return ArchiveType.Zip;
+    if (this.url.endsWith(ArchiveType.SevenZ)) return ArchiveType.SevenZ;
+
+    return ArchiveType.None;
+  }
+
+  async configure() {
+    console.log(`Downloading tool from ${this.url}...`);
+    let downloadPath: string | null = null;
+    let archivePath: string | null = null;
+    const tempDir = path.join(os.tmpdir(), "tmp", "runner", "temp");
+    await io.mkdirP(tempDir);
+    downloadPath = await tc.downloadTool(this.url);
+
+    switch (this.getArchiveType()) {
+      case ArchiveType.None:
+        return this.moveToPath(downloadPath);
+
+      case ArchiveType.TarGz:
+        archivePath = await tc.extractTar(downloadPath, tempDir);
+        return this.moveToPath(path.join(archivePath, this.pathInArchive));
+
+      case ArchiveType.Zip:
+        archivePath = await tc.extractZip(downloadPath, tempDir);
+        return this.moveToPath(path.join(archivePath, this.pathInArchive));
+
+      case ArchiveType.SevenZ:
+        archivePath = await tc.extract7z(downloadPath, tempDir);
+        return this.moveToPath(path.join(archivePath, this.pathInArchive));
+    }
+  }
+
+  async moveToPath(downloadPath: string) {
+    let toolPath = binPath();
+    await io.mkdirP(toolPath);
+    await io.mv(downloadPath, path.join(toolPath, this.name));
+
+    if (process.platform !== "win32") {
+      await exec.exec("chmod", ["+x", path.join(toolPath, this.name)]);
+    }
+
+    core.addPath(toolPath);
+  }
 }
 
 export function binPath(): string {
-    let baseLocation: string;
-    if (process.platform === 'win32') {
-        // On windows use the USERPROFILE env variable
-        baseLocation = process.env['USERPROFILE'] || 'C:\\';
+  let baseLocation: string;
+  if (process.platform === "win32") {
+    // On windows use the USERPROFILE env variable
+    baseLocation = process.env["USERPROFILE"] || "C:\\";
+  } else {
+    if (process.platform === "darwin") {
+      baseLocation = "/Users";
     } else {
-        if (process.platform === 'darwin') {
-            baseLocation = '/Users';
-        } else {
-            baseLocation = '/home';
-        }
+      baseLocation = "/home";
     }
+  }
 
-    return path.join(baseLocation, os.userInfo().username, "configurator", "bin");
+  return path.join(baseLocation, os.userInfo().username, "configurator", "bin");
+}
+
+export enum ArchiveType {
+  None = "",
+  TarGz = ".tar.gz",
+  Zip = ".zip",
+  SevenZ = ".7z",
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,12 +3,7 @@ import * as cfg from "./configurator";
 
 async function run() {
   try {
-    let c = cfg.getConfig();
-    if (c.fromGitHubReleases) {
-      console.log(c);
-      console.log(c.urlTemplate);
-    }
-    //await c.configure();
+    await cfg.getConfig().configure();
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,14 @@
-import * as core from '@actions/core';
-import * as cfg from './configurator';
+import * as core from "@actions/core";
+import * as cfg from "./configurator";
 
 async function run() {
   try {
     let c = cfg.getConfig();
-    await c.configure();
+    if (c.fromGitHubReleases) {
+      console.log(c);
+      console.log(c.urlTemplate);
+    }
+    //await c.configure();
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,0 +1,82 @@
+import * as github from "@actions/github";
+import * as semver from "semver";
+import {
+  ReposListReleasesResponseData,
+  ReposGetReleaseResponseData,
+} from "@octokit/types";
+
+export async function getTag(
+  token: string,
+  repo: string,
+  version: string,
+  includePrereleases: boolean
+): Promise<string> {
+  // the `version` input field can either be a valid semver version, or a
+  // version range. If none of them are valid, throw an error.
+  if (semver.valid(version) === null && semver.validRange(version) === null) {
+    throw new Error(
+      `version input: ${version} is not a valid semver version or range.`
+    );
+  }
+
+  let client = github.getOctokit(token);
+  let owner = repo.split("/")[0];
+  let repoName = repo.split("/")[1];
+
+  // by default, the GitHub releases API returns the first 30 releases.
+  // while we haven't found a suitable release, increment the page index
+  // and iterate through the results.
+  let result: ReposGetReleaseResponseData | undefined;
+  let pageIndex = 1;
+  while (result === undefined) {
+    let releases = await client.repos.listReleases({
+      owner: owner,
+      repo: repoName,
+      page: pageIndex,
+    });
+
+    // if result is still undefined and there are no more releases it means there are actually
+    // no releases that satisty the version constrained. If this happens, throw an error.
+    if (releases.data.length === 0 && result === undefined) {
+      throw new Error(
+        `cannot find suitable release for version constraint ${version} for repo ${owner}/${repo}`
+      );
+    }
+
+    result = searchSatisfyingRelease(
+      releases.data,
+      version,
+      includePrereleases
+    );
+    pageIndex++;
+  }
+
+  console.log(
+    `selected release version ${result.tag_name}, which can be viewed at ${result.url}`
+  );
+  return result.tag_name;
+}
+
+function searchSatisfyingRelease(
+  releases: ReposListReleasesResponseData,
+  version: string,
+  includePrereleases: boolean
+): ReposGetReleaseResponseData | undefined {
+  // normally the release array returned by the API should be ordered by the release date, so
+  // we iterate through it until we find the latest version that satisfies the version constraint.
+  // The initial assumption is that, given that users _should_ want to use recently released versions,
+  // and the number of releases is not (normally) very large, the complexity of this loop should not
+  // be an issue.
+  // However, given that this is an ordered array, we could explore a binary search here.
+  for (let i = 0; i < releases.length; i++) {
+    if (includePrereleases === false && releases[i].prerelease === true) {
+      continue;
+    }
+
+    if (semver.satisfies(releases[i].tag_name, version)) {
+      return releases[i];
+    }
+  }
+
+  return undefined;
+}

--- a/src/release.ts
+++ b/src/release.ts
@@ -13,7 +13,11 @@ export async function getTag(
 ): Promise<string> {
   // the `version` input field can either be a valid semver version, or a
   // version range. If none of them are valid, throw an error.
-  if (semver.valid(version) === null && semver.validRange(version) === null) {
+  if (
+    semver.valid(version) === null &&
+    semver.validRange(version) === null &&
+    version !== "latest"
+  ) {
     throw new Error(
       `version input: ${version} is not a valid semver version or range.`
     );
@@ -69,11 +73,23 @@ function searchSatisfyingRelease(
   // be an issue.
   // However, given that this is an ordered array, we could explore a binary search here.
   for (let i = 0; i < releases.length; i++) {
+    if (version === "latest") {
+      if (
+        (includePrereleases && releases[i].prerelease) ||
+        !releases[i].prerelease
+      ) {
+        return releases[i];
+      }
+    }
+
     if (includePrereleases === false && releases[i].prerelease === true) {
       continue;
     }
-
-    if (semver.satisfies(releases[i].tag_name, version)) {
+    if (
+      semver.satisfies(releases[i].tag_name, version, {
+        includePrerelease: includePrereleases,
+      })
+    ) {
       return releases[i];
     }
   }

--- a/test/action.ts
+++ b/test/action.ts
@@ -1,117 +1,146 @@
-import * as path from 'path';
-import * as os from 'os';
-const toolDir = path.join(os.tmpdir(), 'runner', 'tools');
-const tempDir = path.join(os.tmpdir(), 'tmp', 'runner', 'temp');
-const dataDir = path.join(os.tmpdir(), 'tmp', 'data');
+import * as path from "path";
+import * as os from "os";
+const toolDir = path.join(os.tmpdir(), "runner", "tools");
+const tempDir = path.join(os.tmpdir(), "tmp", "runner", "temp");
+const dataDir = path.join(os.tmpdir(), "tmp", "data");
 
-process.env['RUNNER_TOOL_CACHE'] = toolDir;
-process.env['RUNNER_TEMP'] = tempDir;
+process.env["RUNNER_TOOL_CACHE"] = toolDir;
+process.env["RUNNER_TEMP"] = tempDir;
 
 import "mocha";
 import { assert } from "chai";
-import * as cfg from '../src/configurator';
-import * as fs from 'fs';
-import * as rimraf from 'rimraf';
+import * as cfg from "../src/configurator";
+import * as fs from "fs";
+import * as rimraf from "rimraf";
 
 describe("test archive type", () => {
-    it("correctly chooses the NONE archive type", () => {
-        const archiveTypeNoneInput = {
-            INPUT_URL: 'https://github.com/<some-repo>/releases/download/<release>/some-binary',
-        };
-        for (const key in archiveTypeNoneInput)
-            process.env[key] = archiveTypeNoneInput[key]
-        
-        let c = cfg.getConfig();
-        assert.equal(cfg.ArchiveType.None, c.getArchiveType());
-    });
+  it("correctly chooses the NONE archive type", () => {
+    const archiveTypeNoneInput = {
+      INPUT_URL:
+        "https://github.com/<some-repo>/releases/download/<release>/some-binary",
+    };
+    for (const key in archiveTypeNoneInput)
+      process.env[key] = archiveTypeNoneInput[key];
 
-    it("correctly chooses the TAR.GZ archive type", () => {
-        const archiveTypeTarInput = {
-            INPUT_URL: 'https://github.com/<some-repo>/releases/download/<release>/some-tar-archive.tar.gz',
-        };
-        for (const key in archiveTypeTarInput)
-            process.env[key] = archiveTypeTarInput[key]
-        
-        let c = cfg.getConfig();
-        assert.equal(cfg.ArchiveType.TarGz, c.getArchiveType());
-    });
+    let c = cfg.getConfig();
+    assert.equal(cfg.ArchiveType.None, cfg.getArchiveType(c.url));
+  });
 
-    it("correctly chooses the ZIP archive type", () => {
-        const archiveTypeZipInput = {
-            INPUT_URL: 'https://github.com/<some-repo>/releases/download/<release>/some-tar-archive.zip',
-        };
-        for (const key in archiveTypeZipInput)
-            process.env[key] = archiveTypeZipInput[key]
-        
-        let c = cfg.getConfig();
-        assert.equal(cfg.ArchiveType.Zip, c.getArchiveType());
-    });
+  it("correctly chooses the TAR.GZ archive type", () => {
+    const archiveTypeTarInput = {
+      INPUT_URL:
+        "https://github.com/<some-repo>/releases/download/<release>/some-tar-archive.tar.gz",
+    };
+    for (const key in archiveTypeTarInput)
+      process.env[key] = archiveTypeTarInput[key];
 
-    it("correctly chooses the 7Z archive type", () => {
-        const archiveTypeZipInput = {
-            INPUT_URL: 'https://github.com/<some-repo>/releases/download/<release>/some-tar-archive.7z',
-        };
-        for (const key in archiveTypeZipInput)
-            process.env[key] = archiveTypeZipInput[key];
-        
-        let c = cfg.getConfig();
-        assert.equal(cfg.ArchiveType.SevenZ, c.getArchiveType());
-    });
+    let c = cfg.getConfig();
+    assert.equal(cfg.ArchiveType.TarGz, cfg.getArchiveType(c.url));
+  });
+
+  it("correctly chooses the ZIP archive type", () => {
+    const archiveTypeZipInput = {
+      INPUT_URL:
+        "https://github.com/<some-repo>/releases/download/<release>/some-tar-archive.zip",
+    };
+    for (const key in archiveTypeZipInput)
+      process.env[key] = archiveTypeZipInput[key];
+
+    let c = cfg.getConfig();
+    assert.equal(cfg.ArchiveType.Zip, cfg.getArchiveType(c.url));
+  });
+
+  it("correctly chooses the 7Z archive type", () => {
+    const archiveTypeZipInput = {
+      INPUT_URL:
+        "https://github.com/<some-repo>/releases/download/<release>/some-tar-archive.7z",
+    };
+    for (const key in archiveTypeZipInput)
+      process.env[key] = archiveTypeZipInput[key];
+
+    let c = cfg.getConfig();
+    assert.equal(cfg.ArchiveType.SevenZ, cfg.getArchiveType(c.url));
+  });
 });
 
-describe("test download", async () => {
-    after(() => {
-        rimraf.sync(tempDir);
-        rimraf.sync(cfg.binPath());
-    });
+describe("test URL download", async () => {
+  after(() => {
+    rimraf.sync(tempDir);
+    rimraf.sync(cfg.binPath());
+  });
 
-    it("correctly downloads plain files", async () => {
-        const input = {
-            INPUT_URL: 'https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64',
-            INPUT_NAME: 'kind',
-        }
-        for (const key in input)
-            process.env[key] = input[key];
-        
-        let c = cfg.getConfig();
-        await c.configure();
+  it("correctly downloads plain files", async () => {
+    const input = {
+      INPUT_URL:
+        "https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64",
+      INPUT_NAME: "kind",
+    };
+    for (const key in input) process.env[key] = input[key];
 
-        assert.equal(fs.existsSync(path.join(cfg.binPath(), c.name)), true);
-    });
+    let c = cfg.getConfig();
+    await c.configure();
 
+    assert.equal(fs.existsSync(path.join(cfg.binPath(), c.name)), true);
+  });
 
-    it("correctly downloads .tar.gz files", async () => {
-        if (process.platform === 'win32') {
-            // there seems to be an error with the tar utility on Windows - skipping the test for now
-            return;
-        }
+  it("correctly downloads .tar.gz files", async () => {
+    if (process.platform === "win32") {
+      // there seems to be an error with the tar utility on Windows - skipping the test for now
+      return;
+    }
 
-        const input = {
-            INPUT_URL: 'https://get.helm.sh/helm-v3.0.0-beta.3-linux-amd64.tar.gz',
-            INPUT_NAME: 'hb3',
-            INPUT_PATHINARCHIVE: 'linux-amd64/helm'
-        }
-        for (const key in input)
-            process.env[key] = input[key];
-        
-        let c = cfg.getConfig();
-        await c.configure();
+    const input = {
+      INPUT_URL: "https://get.helm.sh/helm-v3.0.0-beta.3-linux-amd64.tar.gz",
+      INPUT_NAME: "hb3",
+      INPUT_PATHINARCHIVE: "linux-amd64/helm",
+    };
+    for (const key in input) process.env[key] = input[key];
 
-        assert.equal(fs.existsSync(path.join(cfg.binPath(), c.name)), true);
-    });
+    let c = cfg.getConfig();
+    await c.configure();
 
-    it("correctly downloads .zip files", async () => {
-        const input = {
-            INPUT_URL: 'https://get.helm.sh/helm-v3.0.0-beta.3-windows-amd64.zip',
-            INPUT_NAME: 'helm.exe',
-            INPUT_PATHINARCHIVE: 'windows-amd64/helm.exe'
-        }
-        for (const key in input)
-            process.env[key] = input[key];
-        
-        let c = cfg.getConfig();
-        await c.configure();
+    assert.equal(fs.existsSync(path.join(cfg.binPath(), c.name)), true);
+  });
 
-        assert.equal(fs.existsSync(path.join(cfg.binPath(), c.name)), true);
-    });
-})
+  it("correctly downloads .zip files", async () => {
+    const input = {
+      INPUT_URL: "https://get.helm.sh/helm-v3.0.0-beta.3-windows-amd64.zip",
+      INPUT_NAME: "helm.exe",
+      INPUT_PATHINARCHIVE: "windows-amd64/helm.exe",
+    };
+    for (const key in input) process.env[key] = input[key];
+
+    let c = cfg.getConfig();
+    await c.configure();
+
+    assert.equal(fs.existsSync(path.join(cfg.binPath(), c.name)), true);
+  });
+});
+
+describe("test GitHub release download", async () => {
+  after(() => {
+    rimraf.sync(tempDir);
+    rimraf.sync(cfg.binPath());
+  });
+
+  it("correctly downloads based on GitHub release input", async () => {
+    const input = {
+      INPUT_NAME: "h3",
+      INPUT_PATHINARCHIVE: "darwin-amd64/helm",
+      INPUT_FROMGITHUBRELEASES: "true",
+      // before running this test, run export GITHUB_TOKEN=<github-token>
+      INPUT_TOKEN: process.env["GITHUB_TOKEN"],
+      INPUT_REPO: "helm/helm",
+      INPUT_VERSION: "^v3.1.2",
+      INPUT_INCLUDEPRERELEASES: "false",
+      INPUT_URLTEMPLATE:
+        "https://get.helm.sh/helm-{{version}}-darwin-amd64.tar.gz",
+    };
+
+    for (const key in input) process.env[key] = input[key];
+
+    let c = cfg.getConfig();
+    await c.configure();
+    assert.equal(fs.existsSync(path.join(cfg.binPath(), c.name)), true);
+  });
+});


### PR DESCRIPTION
closes #10 
closes #9

A complete workflow file:

```
jobs:
  configurator:
    runs-on: ${{ matrix.config.os }}
    strategy:
      matrix:
        config:
          - {
              os: "ubuntu-latest",
              urlTemplate: "https://get.helm.sh/helm-{{version}}-linux-amd64.tar.gz",
              name: "hb3",
              pathInArchive: "linux-amd64/helm",
            }
          - {
              os: "windows-latest",
              urlTemplate: "https://get.helm.sh/helm-{{version}}-windows-amd64.zip",
              name: "hb3.exe",
              pathInArchive: "windows-amd64/helm.exe",
            }
    steps:
      - uses: actions/checkout@v2
      - name: "npm install"
        run: npm install
      - name: "npm run build"
        run: npm run build

      - uses: ./
        with:
          name: ${{ matrix.config.name }}
          fromGitHubReleases: "true"
          repo: "helm/helm"
          version: "^v3.1.2"
          urlTemplate: ${{ matrix.config.urlTemplate }}
          pathInArchive: ${{ matrix.config.pathInArchive }}
          token: ${{ secrets.GITHUB_TOKEN }}
      - name: Testing
        run: |
          hb3 --help
```

Which generates a run:

```
  with:
    name: hb3
    fromGitHubReleases: true
    repo: helm/helm
    version: ^v3.1.2
    urlTemplate: https://get.helm.sh/helm-{{version}}-linux-amd64.tar.gz
    pathInArchive: linux-amd64/helm
    token: ***
    includePrereleases: false
selected release version v3.3.1, which can be viewed at https://api.github.com/repos/helm/helm/releases/30454831
Downloading tool from https://get.helm.sh/helm-v3.3.1-linux-amd64.tar.gz
/bin/tar xz --warning=no-unknown-keyword -C /tmp/tmp/runner/temp -f /home/runner/work/_temp/8f67bba2-71e5-4afa-9f5a-f76751d77ed4
/bin/chmod +x /home/runner/configurator/bin/hb3
```


The current behavior is as follows:

- the `token` field has to be passed, because when attempting to get the releases, a GitHub client is created, which requires a token.
- the `version` field is a `semver` ([as implemented by NPM](https://docs.npmjs.com/about-semantic-versioning)), and can either be an exact version, or a version range (using ^ or ~).
- the `urlTemplate` field is used by the action to generate the download URL, based on the selected version. Note that the concatenated string is as returned by the `tag_name` field of the GitHub release. This field uses plain [Mustache templates](https://mustache.github.io/) - notice the missing `$` before the template - the GitHub Action engine has no knowledge about this template, and it is used by the action alone.
- extra care should be taken with regards to a trailing `v` between the tag and URL (or its lack).
- the `name` and `pathInArchive` fields are unchanged.
- the action can continue to be used without `fromGitHubReleases`, with a direct URL.

TODO:

- [x] add documentation and examples in readme
- [x] add better descriptions to `action.yml`
- [x] add more tests for getting the correct version ranges
- [ ] explore a `try` block that attempts to add/remove `v` from version URLs in case of failures.
