### PR TITLE
add rawVersion template variable

### DIFF
--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -79,7 +79,8 @@ export class Configurator {
         this.includePrereleases
       );
 
-      downloadURL = Mustache.render(this.urlTemplate, { version: tag });
+      const rawVersion = tag.startsWith("v") ? tag.substr(1) : tag;
+      downloadURL = Mustache.render(this.urlTemplate, { version: tag, rawVersion: rawVersion });
     } else {
       downloadURL = this.url;
     }


### PR DESCRIPTION
I'm trying to install [cuelang](https://github.com/cuelang/cue/releases/tag/v0.3.0-beta.5).
The cuelang download URL has their version in it twice, the latter usage lacks the `v` from semvar:
```
https://github.com/cuelang/cue/releases/download/v0.3.0-beta.5/cue_0.3.0-beta.5_Linux_x86_64.tar.gz
```

This change proposes adding another template variable `rawVersion` (naming suggestions welcome) that strips the leading `v` off of the version.

The resulting templateURL for cuelang would become:
```
https://github.com/cuelang/cue/releases/download/{{version}}/cue_{{rawVersion}}_Linux_x86_64.tar.gz
```

The final YAML would be:

```yaml
    - name: Install cue from GitHub
      uses: engineerd/configurator@v0.0.5
      with:
        name: cue
        pathInArchive: cue
        fromGitHubReleases: true
        repo: cuelang/cue
        version: ^v0.3.0-beta
        urlTemplate: https://github.com/cuelang/cue/releases/download/v{{version}}/cue_{{rawVersion}}_Linux_x86_64.tar.gz
        token: ${{ secrets.GITHUB_TOKEN }}
```